### PR TITLE
Correcting markdown formatting issues in spring-ejb-and-jpa

### DIFF
--- a/content/spring-ejb-and-jpa.mdtext
+++ b/content/spring-ejb-and-jpa.mdtext
@@ -11,26 +11,15 @@ objects in one application.  The premise of the example is a Cineplex that
 has a number of Theaters (viewing screens), each playing a number of
 Movies.  The basic object layout is as follows:
 
-<table>
-<tr><th> Object </th><th> Type </th><th> Description </th></tr>
-<tr><td> [CineplexImpl](http://svn.apache.org/repos/asf/tomee/tomee/trunk/examples/spring-integration/src/main/java/org/superbiz/spring/CineplexImpl.java)
- </td><td> @Stateless </td><td> Shows the use of @Resource to have Spring beans injected.
-Specifically, the _Theaters_ Spring bean </td></tr>
-<tr><td> [Theaters](http://svn.apache.org/repos/asf/tomee/tomee/trunk/examples/spring-integration/src/main/java/org/superbiz/spring/Theaters.java)
- </td><td> Spring bean </td><td> Simple wrapper object injected into _CineplexImpl_ </td></tr>
-<tr><td> [Theater](http://svn.apache.org/repos/asf/tomee/tomee/trunk/examples/spring-integration/src/main/java/org/superbiz/spring/Theater.java)
- </td><td> Spring bean </td><td> Shows that EJBs can be injected into Spring beans.  Uses
-both the _Movies_ EJB and the _Movie_ JPA objects </td></tr>
-<tr><td> [MoviesImpl](http://svn.apache.org/repos/asf/tomee/tomee/trunk/examples/spring-integration/src/main/java/org/superbiz/spring/MoviesImpl.java)
- </td><td> @Stateful </td><td> Wraps a JPA EntityManager and provides transactional access
-to the persistent _Movie_ objects </td></tr>
-<tr><td> [Movie](http://svn.apache.org/repos/asf/tomee/tomee/trunk/examples/spring-integration/src/main/java/org/superbiz/spring/Movie.java)
- </td><td> @Entity </td><td> Basic JPA bean that is used both by Spring beans and EJBs. 
-The same _Movie_ object as in all the other persistence related examples. </td></tr>
-<tr><td> [AvailableMovies](http://svn.apache.org/repos/asf/tomee/tomee/trunk/examples/spring-integration/src/main/java/org/superbiz/spring/AvailableMovies.java)
- </td><td> Spring bean </td><td> Simple object used as a clever way to seed the
-EntityManager (and really, the database) with persistent _Movie_ objects </td></tr>
-</table>
+
+| Object        | Type          | Description  |
+| ------------- | ------------- | ------------ |
+| [CineplexImpl](http://svn.apache.org/repos/asf/tomee/tomee/trunk/examples/spring-integration/src/main/java/org/superbiz/spring/CineplexImpl.java) | `@Stateless` | Shows the use of `@Resource` to have Spring beans injected. Specifically, the _Theaters_ Spring bean |
+| [Theaters](http://svn.apache.org/repos/asf/tomee/tomee/trunk/examples/spring-integration/src/main/java/org/superbiz/spring/Theaters.java) | Spring bean | Simple wrapper object injected into _CineplexImpl_ |
+| [Theater](http://svn.apache.org/repos/asf/tomee/tomee/trunk/examples/spring-integration/src/main/java/org/superbiz/spring/Theater.java) | Spring bean | Shows that EJBs can be injected into Spring beans.  Uses both the _Movies_ EJB and the _Movie_ JPA objects |
+| [MoviesImpl](http://svn.apache.org/repos/asf/tomee/tomee/trunk/examples/spring-integration/src/main/java/org/superbiz/spring/MoviesImpl.java) | @Stateful | Wraps a JPA EntityManager and provides transactional access to the persistent _Movie_ objects |
+| [Movie](http://svn.apache.org/repos/asf/tomee/tomee/trunk/examples/spring-integration/src/main/java/org/superbiz/spring/Movie.java) | `@Entity` |  Basic JPA bean that is used both by Spring beans and EJBs. The same _Movie_ object as in all the other persistence related examples.|
+| [AvailableMovies](http://svn.apache.org/repos/asf/tomee/tomee/trunk/examples/spring-integration/src/main/java/org/superbiz/spring/AvailableMovies.java) | Spring bean | Simple object used as a clever way to seed the `EntityManager` (and really, the database) with persistent _Movie_ objects |
 
 <a name="SpringEJBandJPA-Requiredjars"></a>
 # Required jars
@@ -109,62 +98,42 @@ $ mvn clean install
 
 Which should create output like the following.
 
-
+```txt
     -------------------------------------------------------
      T E S T S
     -------------------------------------------------------
     Running org.superbiz.spring.MoviesTest
-    log4j:WARN No appenders could be found for logger
-(org.springframework.context.support.ClassPathXmlApplicationContext).
+    log4j:WARN No appenders could be found for logger (org.springframework.context.support.ClassPathXmlApplicationContext).
     log4j:WARN Please initialize the log4j system properly.
     Apache OpenEJB 3.1    build: 20081009-03:31
     http://tomee.apache.org/
-    INFO - openejb.home =
-/Users/dblevins/work/openejb3/examples/spring-integration
-    INFO - openejb.base =
-/Users/dblevins/work/openejb3/examples/spring-integration
-    INFO - Configuring Service(id=Default JDK 1.3 ProxyFactory,
-type=ProxyFactory, provider-id=Default JDK 1.3 ProxyFactory)
-    INFO - Configuring Service(id=MovieDatabase, type=Resource,
-provider-id=Default JDBC Database)
-    INFO - Configuring Service(id=MovieDatabaseUnmanaged, type=Resource,
-provider-id=Default JDBC Database)
-    INFO - Found EjbModule in classpath:
-/Users/dblevins/work/openejb3/examples/spring-integration/target/classes
-    INFO - Beginning load:
-/Users/dblevins/work/openejb3/examples/spring-integration/target/classes
+    INFO - openejb.home = /Users/dblevins/work/openejb3/examples/spring-integration
+    INFO - openejb.base = /Users/dblevins/work/openejb3/examples/spring-integration
+    INFO - Configuring Service(id=Default JDK 1.3 ProxyFactory, type=ProxyFactory, provider-id=Default JDK 1.3 ProxyFactory)
+    INFO - Configuring Service(id=MovieDatabase, type=Resource, provider-id=Default JDBC Database)
+    INFO - Configuring Service(id=MovieDatabaseUnmanaged, type=Resource, provider-id=Default JDBC Database)
+    INFO - Found EjbModule in classpath: /Users/dblevins/work/openejb3/examples/spring-integration/target/classes
+    INFO - Beginning load: /Users/dblevins/work/openejb3/examples/spring-integration/target/classes
     INFO - Configuring enterprise application: classpath.ear
-    INFO - Configuring Service(id=Default Stateless Container, type=Container,
-provider-id=Default Stateless Container)
-    INFO - Auto-creating a container for bean CineplexImpl:
-Container(type=STATELESS, id=Default Stateless Container)
-    INFO - Auto-linking resource-ref
-'org.superbiz.spring.CineplexImpl/theaters' in bean CineplexImpl to
-Resource(id=theaters)
-    INFO - Configuring Service(id=Default Stateful Container, type=Container,
-provider-id=Default Stateful Container)
-    INFO - Auto-creating a container for bean Movies: Container(type=STATEFUL,
-id=Default Stateful Container)
-    INFO - Configuring PersistenceUnit(name=movie-unit,
-provider=org.hibernate.ejb.HibernatePersistence)
+    INFO - Configuring Service(id=Default Stateless Container, type=Container, provider-id=Default Stateless Container)
+    INFO - Auto-creating a container for bean CineplexImpl: Container(type=STATELESS, id=Default Stateless Container)
+    INFO - Auto-linking resource-ref 'org.superbiz.spring.CineplexImpl/theaters' in bean CineplexImpl to Resource(id=theaters)
+    INFO - Configuring Service(id=Default Stateful Container, type=Container, provider-id=Default Stateful Container)
+    INFO - Auto-creating a container for bean Movies: Container(type=STATEFUL, id=Default Stateful Container)
+    INFO - Configuring PersistenceUnit(name=movie-unit, provider=org.hibernate.ejb.HibernatePersistence)
     INFO - Enterprise application "classpath.ear" loaded.
     INFO - Assembling app: classpath.ear
-    INFO - PersistenceUnit(name=movie-unit,
-provider=org.hibernate.ejb.HibernatePersistence)
+    INFO - PersistenceUnit(name=movie-unit, provider=org.hibernate.ejb.HibernatePersistence)
     INFO - Jndi(name=CineplexImplLocal) --> Ejb(deployment-id=CineplexImpl)
     INFO - Jndi(name=MoviesLocal) --> Ejb(deployment-id=Movies)
-    INFO - Created Ejb(deployment-id=Movies, ejb-name=Movies, container=Default
-Stateful Container)
-    INFO - Created Ejb(deployment-id=CineplexImpl, ejb-name=CineplexImpl,
-container=Default Stateless Container)
+    INFO - Created Ejb(deployment-id=Movies, ejb-name=Movies, container=Default Stateful Container)
+    INFO - Created Ejb(deployment-id=CineplexImpl, ejb-name=CineplexImpl, container=Default Stateless Container)
     INFO - Deployed Application(path=classpath.ear)
-    INFO - Exported EJB Movies with interface org.superbiz.spring.Movies to
-Spring bean MoviesLocal
-    INFO - Exported EJB CineplexImpl with interface
-org.superbiz.spring.Cineplex to Spring bean CineplexImplLocal
+    INFO - Exported EJB Movies with interface org.superbiz.spring.Movies to Spring bean MoviesLocal
+    INFO - Exported EJB CineplexImpl with interface org.superbiz.spring.Cineplex to Spring bean CineplexImplLocal
     Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.141 sec
     
     Results :
     
     Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
-
+```


### PR DESCRIPTION
NOTE: I didn't actually try the tomee-site build, I just hacked on the file in GitHub.

There are a bunch of other tags that do NOT render (assume they are preprocessed) (`{note}`, `{snippet}`.

See: https://tomee.apache.org/spring-ejb-and-jpa.html
